### PR TITLE
added more steps needed to use alert app

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,8 @@
     Put the "alert" directory somewhere in your python path
 
  2. Add "alert" to your installed apps (in the settings.py file)
+ 3. Also add "django.contrib.sites" in installed apps in case it's not there.
+ 4. Run ./manage.py migrate
 
 
 ## Making Alerts ##


### PR DESCRIPTION
These steps were needed to use alert app. I tested it with `Django==1.6.2`.
