### PR TITLE
Boolean's default set explicitly to False

### DIFF
--- a/alert/models.py
+++ b/alert/models.py
@@ -62,7 +62,7 @@ class AlertPreference(models.Model):
     alert_type = models.CharField(max_length=25, choices=ALERT_TYPE_CHOICES)
     backend = models.CharField(max_length=25, choices=ALERT_BACKEND_CHOICES)
     
-    preference = models.BooleanField()
+    preference = models.BooleanField(default=False)
     
     objects = AlertPrefsManager()
     


### PR DESCRIPTION
...so we keep the same behavior
(Django 1.6 introduced _default=None_, while prior versions had _default=False_)
