### PR TITLE
Django 1.8: find_template no longer available

### DIFF
--- a/alert/utils.py
+++ b/alert/utils.py
@@ -3,8 +3,7 @@ from alert.exceptions import AlertIDAlreadyInUse, AlertBackendIDAlreadyInUse,\
 import django
 from django.conf import settings
 from django.utils import timezone
-from django.template.loader import render_to_string
-from django.template.loader import get_template
+from django.template.loader import render_to_string, get_template
 from django.contrib.sites.models import Site
 from django.template import TemplateDoesNotExist
 from django.db import models

--- a/alert/utils.py
+++ b/alert/utils.py
@@ -3,7 +3,8 @@ from alert.exceptions import AlertIDAlreadyInUse, AlertBackendIDAlreadyInUse,\
 import django
 from django.conf import settings
 from django.utils import timezone
-from django.template.loader import render_to_string, find_template
+from django.template.loader import render_to_string
+from django.template.loader import get_template
 from django.contrib.sites.models import Site
 from django.template import TemplateDoesNotExist
 from django.db import models
@@ -142,13 +143,13 @@ class BaseAlert(object):
     def _get_template(self, backend, part, filetype='txt'):
         template = "alerts/%s/%s/%s.%s" % (self.id, backend.id, part, filetype)
         try:
-            find_template(template)
+            get_template(template)
             return template
         except TemplateDoesNotExist:
             pass
         
         template = "alerts/%s/%s.%s" % (self.id, part, filetype)
-        find_template(template)
+        get_template(template)
         
         return template
         


### PR DESCRIPTION
[find_template](https://docs.djangoproject.com/en/1.8/releases/1.8/#cleanup-of-the-django-template-namespace) no longer available in 1.8, so get_template seemed like a replacement